### PR TITLE
Added tray icon for the possiblity to have todoist-linux open in the background

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,6 +1,16 @@
 var gui = require('nw.gui');
 var mainWindow = gui.Window.get();
 
+var tray = new gui.Tray({ title: 'Todoist', icon: 'assets/icon.png' });
+
+var menu = new gui.Menu();
+var exitItem = new gui.MenuItem({ type: 'normal', label: 'Exit' });
+menu.append(exitItem);
+tray.menu = menu;
+
+var window_minimized = false;
+var window_hidden = false;
+
 var view = document.getElementById('view');
 var loader = document.querySelector('.loader');
 
@@ -97,7 +107,32 @@ view.addEventListener('load', function () {
   redirectLink(winFrame);
 });
 
+tray.on('click', function() {
+  if(window_minimized) {
+    mainWindow.restore();
+    window_minimized = false;
+  }
+  else if(window_hidden) {
+    mainWindow.show();
+    window_hidden = false;
+  }
+  else {
+    mainWindow.focus();
+  }
+});
+
+mainWindow.on('minimize', function() {
+  window_minimized = true;
+});
+
 mainWindow.on('close', function() {
   this.hide();
-  this.close(true);
+  window_hidden = true;
 });
+
+exitItem.click = function() {
+  if(!window_hidden) {
+    mainWindow.hide();
+  }
+  mainWindow.close(true);
+};


### PR DESCRIPTION
Hey,
this modification creats a trayicon with the following options
- The close button of the main window now hides the window
- The minimise button minimises the window as before
- The tray icon can be used to restore or maximise the window again (or to bring it in focus in case it is just in the background)
- Exit is implemented via a right click menu on the tray icon

I hope this is useful. The idea behind is to have the possiblity to hide the app away nicely and nevertheless be able to have it available quickly without restarting it.

Cheers.
