### PR TITLE
Leave running in tray when closing main window

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -4,7 +4,6 @@ var trayCreated = false;
 
 mainWindow.on('close', function () {
   this.hide();
-  this.close(true);
 });
 
 mainWindow.on('loaded', function () {

--- a/scripts/tray.js
+++ b/scripts/tray.js
@@ -14,7 +14,7 @@ var createTray = function () {
   var quitMenuItem = new nw.MenuItem({
     label: 'Quit',
     click: function () {
-      mainWindow.close();
+      mainWindow.close(true);
     }
   });
 
@@ -30,7 +30,9 @@ var createTray = function () {
   var hideMenuItem = new nw.MenuItem({
     label: 'Hide',
     click: function () {
-      mainWindow.minimize();
+      tray.menu = menuWithShow
+      mainWindow.hide();
+      mainWindowVisible = false;
     }
   });
 
@@ -42,7 +44,7 @@ var createTray = function () {
 
   tray.menu = menuWithHide;
 
-  mainWindow.on('minimize', function() {
+  mainWindow.on('close', function() {
     this.hide();
     tray.menu = menuWithShow;
     mainWindowVisible = false;
@@ -53,8 +55,6 @@ var createTray = function () {
       tray.menu = menuWithHide;
       mainWindow.show();
       mainWindowVisible = true;
-    } else {
-      mainWindow.minimize();
     }
   });
 };


### PR DESCRIPTION
This changes the behaviour of the close button on the main window and the _Hide_ option of the tray menu: they now **hide** the main window (instead of minimising).
Note: with these changes the _Quit_ option is the only way to close the application.